### PR TITLE
fix(quiz): move answers event handler from quizGame.js to App.js

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -1,6 +1,6 @@
 import { player } from "./player.js";
 import {getModeProperties} from './gameMode';
-import { startQuiz } from "./quizGame.js";
+import { startQuiz, checkAnswer } from "./quizGame.js";
 import {getLocalScores, clearLocalScoreList, saveLocalScores} from  "./localScoreboard"
 import {getGlobalScores, clearGlobalScoreList} from './globalScoreboard';
 
@@ -123,13 +123,10 @@ export const App = ({options}) => {
     }
 
     //Funkcja klik, może się przyda
-    // const cbox = document.querySelectorAll(".answer");
-
-    //  for (let i = 0; i < cbox.length; i++) {
-    //      cbox[i].addEventListener("click", function() {
-    //        console.log('Hello');
-    //      });
-    //  }
+    const cbox = document.querySelectorAll(".answer");
+     for (let i = 0; i < cbox.length; i++) {
+         cbox[i].addEventListener("click", (e) => checkAnswer(modeSelected, e));
+     }
 
     //Operator stopki
 

--- a/src/app/quizGame.js
+++ b/src/app/quizGame.js
@@ -32,12 +32,11 @@ const displayQuestion = async(mode, id) => {
     answer.innerText = question.answers[index].content;
     if(question.answers[index].isCorrect) answer.dataset.type = "correct";
     else answer.dataset.type = "incorrect";
-    answer.addEventListener('click', checkAnswer.bind(null, mode));
     possiblityToAnswer = true;
   });
 }
 
-const checkAnswer = (mode, e) => {
+export const checkAnswer = (mode, e) => {
   let classToApply;
   const noHoverClass = 'no-hover';
   if (!possiblityToAnswer) return;


### PR DESCRIPTION
Wykryłam błąd i tutaj jest on już naprawiony. Wszystko opisane w rozwinięciu commita. 
Błąd pojawiał się po **ponownym** wybraniu innej kategorii quizu. Pytania generowane po pierwszym zdarzeniu (click event)  były z kategorii wybranej jako pierwsza zaraz po uruchomieniu aplikacji (co też czasami powodowało błędy przy pobieraniu danych ze względu na różne id pytań w każdej z kategorii). 